### PR TITLE
Updated version checking code

### DIFF
--- a/src/aohara/common/Version.java
+++ b/src/aohara/common/Version.java
@@ -1,0 +1,59 @@
+package aohara.common;
+
+
+
+public class Version {
+    private String m_versionString;
+    private String[] m_versionParts;
+
+    private Version(String versionStr) {
+        m_versionParts=versionStr.split("\\.");
+        m_versionString = versionStr;
+    }
+    
+    public boolean greaterThan(Version other) {
+        if(other==null) {
+            System.out.printf("'%s'>'%s'\n", this, other);
+            return true;
+        }
+        for(int n=0;n<m_versionParts.length && n<other.m_versionParts.length;n++) {
+            String thisPart = m_versionParts[n];
+            String otherPart = other.m_versionParts[n];
+            System.out.printf("'%s'?'%s'---",thisPart,otherPart);
+            try {
+                int thisNum = Integer.parseInt(thisPart);
+                int otherNum = Integer.parseInt(otherPart);
+                if(thisNum!=otherNum) {
+                    System.out.printf("'%s'%s'%s (%d,%d)'\n", this, (thisNum>otherNum?">":"<"),other, thisNum, otherNum);
+                    return thisNum>otherNum;
+                }
+            } catch (NumberFormatException e) {
+                //one or both are not numbers so just do a string comparison
+                int cmpRes = thisPart.compareTo(otherPart);
+                if(cmpRes!=0) {
+                    System.out.printf("'%s'%s'%s' ('%s','%s')\n", this, (cmpRes>0?">":"<"),other,thisPart,otherPart);
+                    return cmpRes>0;
+                }
+            }
+        }
+        //we have compared all the matching parts and they all match
+        //the version with the most parts is greater.
+        System.out.printf("'%s'%s'%s' l(%d,%d)\n", this, (m_versionParts.length > other.m_versionParts.length?">":"<"),other,
+                          m_versionParts.length,other.m_versionParts.length);
+        return m_versionParts.length > other.m_versionParts.length;
+    }
+    
+    public String getNormalVersion() {
+        return m_versionString;
+    }
+    
+    public static Version valueOf(String versionStr) {
+        if(versionStr==null || versionStr.isEmpty())
+            throw new IllegalArgumentException("Input string is NULL or empty");
+        return new Version(versionStr);
+    }
+
+    public String toString() {
+        return m_versionString;
+    }
+}

--- a/src/aohara/common/Version.java
+++ b/src/aohara/common/Version.java
@@ -13,33 +13,27 @@ public class Version {
     
     public boolean greaterThan(Version other) {
         if(other==null) {
-            System.out.printf("'%s'>'%s'\n", this, other);
             return true;
         }
         for(int n=0;n<m_versionParts.length && n<other.m_versionParts.length;n++) {
             String thisPart = m_versionParts[n];
             String otherPart = other.m_versionParts[n];
-            System.out.printf("'%s'?'%s'---",thisPart,otherPart);
             try {
                 int thisNum = Integer.parseInt(thisPart);
                 int otherNum = Integer.parseInt(otherPart);
                 if(thisNum!=otherNum) {
-                    System.out.printf("'%s'%s'%s (%d,%d)'\n", this, (thisNum>otherNum?">":"<"),other, thisNum, otherNum);
                     return thisNum>otherNum;
                 }
             } catch (NumberFormatException e) {
                 //one or both are not numbers so just do a string comparison
                 int cmpRes = thisPart.compareTo(otherPart);
                 if(cmpRes!=0) {
-                    System.out.printf("'%s'%s'%s' ('%s','%s')\n", this, (cmpRes>0?">":"<"),other,thisPart,otherPart);
                     return cmpRes>0;
                 }
             }
         }
         //we have compared all the matching parts and they all match
         //the version with the most parts is greater.
-        System.out.printf("'%s'%s'%s' l(%d,%d)\n", this, (m_versionParts.length > other.m_versionParts.length?">":"<"),other,
-                          m_versionParts.length,other.m_versionParts.length);
         return m_versionParts.length > other.m_versionParts.length;
     }
     
@@ -48,8 +42,9 @@ public class Version {
     }
     
     public static Version valueOf(String versionStr) {
-        if(versionStr==null || versionStr.isEmpty())
+        if(versionStr==null || versionStr.isEmpty()) {
             throw new IllegalArgumentException("Input string is NULL or empty");
+        }
         return new Version(versionStr);
     }
 

--- a/src/aohara/common/VersionParser.java
+++ b/src/aohara/common/VersionParser.java
@@ -18,26 +18,7 @@ public class VersionParser {
 		
 		Matcher m = VERSION_PATTERN.matcher(string);
 		if (m.find()){
-			// Split numbers
-			String group = m.group().replace("-", ".");
-			List<String> numbers = new ArrayList<>(Arrays.asList(group.split("\\.")));
-			
-			// If less than 3 numbers, add a third
-			if (numbers.size() < MAX_PERIODS + 1){
-				numbers.add("0");
-			}
-			
-			// Join numbers back into a version string
-			StringBuilder builder = new StringBuilder();
-			for (int i=0; i<numbers.size(); i++){
-				builder.append(numbers.get(i));
-				if (i < MAX_PERIODS){
-					builder.append(".");
-				}
-				
-			}
-
-			return builder.toString();
+			return m.group().replace("-", ".");
 		}
 		return null;
 	}


### PR DESCRIPTION
The current version checking code is broken for some mods on curseforge
http://www.curse.com/ksp-mods/kerbal/223730-kerbol-positioning-system
http://www.curse.com/ksp-mods/kerbal/220289-kerbal-alarm-clock

Since you are only using it to compare version numbers I have written some custom code that allows mods with versions that do not conform to the semver standard.

This is not just a compatibility request though. With the code used in VersionParser TinkerTime would mistakenly use old versions of mods under certain conditions:
old mod version: <1.0.1.21>
new mod version <1.0.10.1>
The code in VersionParser that made sure there are exactly 3 version numbers would create the following version strings:
<1.0.121>(old) and <1.0.101>(new)
This would cause the jsemver code to conclude that the old file is actually newer than the new file.

There is another pull request for TinkerTime itself so that it uses the custom version checker.